### PR TITLE
fix(installations): set hard-coded per_page

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -106,7 +106,7 @@ async function getInstallationToken(appToken, installationId) {
 async function getInstallationRepositories(userToken) {
   logger.debug('getInstallationRepositories()');
   try {
-    const url = process.env.RENOVATE_ENDPOINT + '/installation/repositories';
+    const url = process.env.RENOVATE_ENDPOINT + '/installation/repositories?per_page=100';
     const options = {
       json: true,
       headers: {


### PR DESCRIPTION
GitHub's installations end-point only returns the first 30 repositories
belonging to an installation, even if there are more repositories
belonging to that installation.

Set hard-coded `per_page` value when fetching repositories belonging
to an installation. Value is set to 100 because that is the maximum that
GitHub will return for any single API fetch.

This is a temporary change because some installations may have more
than 100 repositories belonging to the installation.